### PR TITLE
Reconcile package.xml and changelog versions.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>robot_state_publisher</name>
-  <version>0.0.0</version>
+  <version>1.13.4</version>
   <description>ROS2 version of the robot_state_publisher package</description>
   <maintainer email="karsten@osrfoundation.org">Karsten Knese</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
Unless there's a reason for changing the versioning, just setting the package version to the current changelog version will quiet warnings from Bloom.