### PR TITLE
Revert "Use standard urdfdom-headers rosdep key."

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>urdf</build_depend>
-  <build_depend>urdfdom-headers</build_depend>
+  <build_depend>urdfdom_headers</build_depend>
 
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>kdl_parser</exec_depend>
@@ -25,7 +25,7 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>urdf</exec_depend>
-  <exec_depend>urdfdom-headers</exec_depend>
+  <exec_depend>urdfdom_headers</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Reverts ros2/robot_state_publisher#4 while this isn't breaking CI. The same underlying problem exists with this and https://github.com/ros2/urdfdom/pull/3 and they should all be resolved together.