### PR TITLE
Rename dependency key for urdfdom-headers.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>urdf</build_depend>
-  <build_depend>urdfdom_headers</build_depend>
+  <build_depend>urdfdom-headers</build_depend>
 
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>kdl_parser</exec_depend>
@@ -25,7 +25,7 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>urdf</exec_depend>
-  <exec_depend>urdfdom_headers</exec_depend>
+  <exec_depend>urdfdom-headers</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
We're shadowing this key for r2b2 since upstream is out of date but we should
use the rosdep key so we can eventually target upstream.

https://github.com/ros2/robot_model/pull/1

This is the second attempt to do so after the first failed due to the
urdfdom_headers package not being renamed for source builds. That is
being resolved by placing a package.xml with the updated name in the
source tree rather than in a release patch.