### PR TITLE
tinyxml is never found_package'd so this variable is always empty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,6 @@ target_link_libraries(
   joint_state_listener
   ${orocos_kdl_LIBRARIES}
   ${kdl_parser_LIBRARIES}
-  ${tinyxml_LIBRARIES}
   ${urdf_LIBRARIES}
   ${rclcpp_LIBRARIES}
   ${tf2_ros_LIBRARIES}


### PR DESCRIPTION
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4012)](http://ci.ros2.org/job/ci_linux/4012/) (test failure unrelated)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1108)](http://ci.ros2.org/job/ci_linux-aarch64/1108/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3334)](http://ci.ros2.org/job/ci_osx/3334/) (unrelated test failures)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4100)](http://ci.ros2.org/job/ci_windows/4100/) (unrelated test failures, warning unrelated as well)