### PR TITLE
ABI compatible use_sime_time fix for Dashing

### DIFF
--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -47,7 +47,7 @@
 #include "sensor_msgs/msg/joint_state.hpp"
 #include "urdf/model.h"
 
-#include "robot_state_publisher/robot_state_publisher.h"
+#include "robot_state_publisher/robot_state_publisher_dashing_hack.h"
 
 typedef std::shared_ptr<sensor_msgs::msg::JointState const> JointStateConstPtr;
 typedef std::map<std::string, urdf::JointMimicSharedPtr> MimicMap;
@@ -75,7 +75,7 @@ protected:
   rclcpp::Node::SharedPtr node_;
   std::string tf_prefix_;
   std::chrono::seconds publish_interval_;
-  robot_state_publisher::RobotStatePublisher state_publisher_;
+  robot_state_publisher::RobotStatePublisherDashingHack state_publisher_;
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_state_sub_;
   rclcpp::TimerBase::SharedPtr timer_;
   std::chrono::time_point<std::chrono::system_clock> last_callback_time_;

--- a/include/robot_state_publisher/robot_state_publisher_dashing_hack.h
+++ b/include/robot_state_publisher/robot_state_publisher_dashing_hack.h
@@ -1,0 +1,102 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef ROBOT_STATE_PUBLISHER__ROBOT_STATE_PUBLISHER_DASHING_HACK_H_
+#define ROBOT_STATE_PUBLISHER__ROBOT_STATE_PUBLISHER_DASHING_HACK_H_
+
+#include "robot_state_publisher/robot_state_publisher.h"
+
+namespace robot_state_publisher
+{
+// Hack for Dashing patch release
+// This makes timestamps on static transforms obey use_sim_time in Dashing
+class RobotStatePublisherDashingHack : public RobotStatePublisher
+{
+public:
+  RobotStatePublisherDashingHack(
+    rclcpp::Node::SharedPtr node_handle, const KDL::Tree & tree,
+    const urdf::Model & model, const std::string & model_xml)
+    : RobotStatePublisher(node_handle, tree, model, model_xml),
+    clock_(node_handle->get_clock())
+  {
+  }
+
+  virtual ~RobotStatePublisherDashingHack()
+  {
+  }
+
+  // Copy/pasted from robot_state_publisher.cpp
+  inline
+  geometry_msgs::msg::TransformStamped kdlToTransform(const KDL::Frame & k)
+  {
+    geometry_msgs::msg::TransformStamped t;
+    t.transform.translation.x = k.p.x();
+    t.transform.translation.y = k.p.y();
+    t.transform.translation.z = k.p.z();
+    k.M.GetQuaternion(t.transform.rotation.x, t.transform.rotation.y, t.transform.rotation.z,
+      t.transform.rotation.w);
+    return t;
+  }
+
+  // Mostly copy/pasted from robot_state_publisher.cpp
+  void publishFixedTransforms(const std::string & tf_prefix, bool use_tf_static = false) override
+  {
+    std::vector<geometry_msgs::msg::TransformStamped> tf_transforms;
+    geometry_msgs::msg::TransformStamped tf_transform;
+
+    // loop over all fixed segments
+    for (auto seg = segments_fixed_.begin(); seg != segments_fixed_.end(); seg++) {
+      geometry_msgs::msg::TransformStamped tf_transform = kdlToTransform(seg->second.segment.pose(0));
+      rclcpp::Time now = clock_->now();
+      if (!use_tf_static) {
+        now = now + rclcpp::Duration(std::chrono::milliseconds(500));  // 0.5sec in NS
+      }
+      tf_transform.header.stamp = now;
+
+      tf_transform.header.frame_id = tf_prefix + "/" + seg->second.root;
+      tf_transform.child_frame_id = tf_prefix + "/" + seg->second.tip;
+      tf_transforms.push_back(tf_transform);
+    }
+    if (use_tf_static) {
+      static_tf_broadcaster_.sendTransform(tf_transforms);
+    } else {
+      tf_broadcaster_.sendTransform(tf_transforms);
+    }
+  }
+
+private:
+  rclcpp::Clock::SharedPtr clock_;
+};
+}
+#endif


### PR DESCRIPTION
This is a companion PR to #20. #20 is a proper fix that should go into eloquent. This is a hack that may be acceptable for a Dashing patch release.

This creates a robot state publisher subclass that uses ROS time for static transforms to avoid breaking ABI. This PR does change the size of the class `JointStateListener` which is in a publicly installed header. This it is probably ok because `joint_state_listener.cpp` contains a `main()`. It seems unlikely that anyone would have included `joint_state_listener.h`.

Personally, after making this PR, it is probably worth breaking ABI in Dashing and do a patch release with #20 instead of merging this PR