### PR TITLE
Use rclcpp::Time for stamping transforms (#20)

### DIFF
--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -99,6 +99,7 @@ protected:
   std_msgs::msg::String model_xml_;
   bool description_published_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr description_pub_;
+  rclcpp::Clock::SharedPtr clock_;
 };
 
 }  // namespace robot_state_publisher


### PR DESCRIPTION
* Use rclcpp::Time for stamping transforms

The motivation is that right now, `robot_state_publisher` doesn't respect
`use_sim_time` at all.

* Use std::chrono constructor to represent 0.5 sec