### PR TITLE
Publish URDF string on startup.  

### DIFF
--- a/include/robot_state_publisher/robot_state_publisher.h
+++ b/include/robot_state_publisher/robot_state_publisher.h
@@ -97,7 +97,6 @@ protected:
   tf2_ros::TransformBroadcaster tf_broadcaster_;
   tf2_ros::StaticTransformBroadcaster static_tf_broadcaster_;
   std_msgs::msg::String model_xml_;
-  bool description_published_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr description_pub_;
   rclcpp::Clock::SharedPtr clock_;
 };

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -76,7 +76,6 @@ RobotStatePublisher::RobotStatePublisher(
 : model_(model),
   tf_broadcaster_(node_handle),
   static_tf_broadcaster_(node_handle),
-  description_published_(false),
   clock_(node_handle->get_clock())
 {
   // walk the tree and add segments to segments_
@@ -89,11 +88,8 @@ RobotStatePublisher::RobotStatePublisher(
     // Transient local is similar to latching in ROS 1.
     rclcpp::QoS(1).transient_local());
 
-  // Publish the robot description, as necessary
-  if (!description_published_) {
-    description_pub_->publish(model_xml_);
-    description_published_ = true;
-  }
+  // Publish the robot description
+  description_pub_->publish(model_xml_);
 }
 
 // add children to correct maps

--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -88,6 +88,12 @@ RobotStatePublisher::RobotStatePublisher(
     "robot_description",
     // Transient local is similar to latching in ROS 1.
     rclcpp::QoS(1).transient_local());
+
+  // Publish the robot description, as necessary
+  if (!description_published_) {
+    description_pub_->publish(model_xml_);
+    description_published_ = true;
+  }
 }
 
 // add children to correct maps
@@ -143,12 +149,6 @@ void RobotStatePublisher::publishTransforms(
     }
   }
   tf_broadcaster_.sendTransform(tf_transforms);
-
-  // Publish the robot description, as necessary
-  if (!description_published_) {
-    description_pub_->publish(model_xml_);
-    description_published_ = true;
-  }
 }
 
 // publish fixed transforms


### PR DESCRIPTION
Don't wait until /joint_states is received.  This allows unit testts and other programs that want to use the URDF (without parsing it themselves) but might not be hooked up to a live robot/simulation, or even know what joints exist before getting this URDF string.