### PR TITLE
[backport] don't export exe as library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,5 @@ endif()
 
 ament_export_libraries(
   ${PROJECT_NAME}_solver
-  joint_state_listener
-  ${PROJECT_NAME})
+  joint_state_listener)
 ament_package()


### PR DESCRIPTION
backport of ros2/robot_state_publisher#25