### PR TITLE
Pass tf_prefix as parameter

### DIFF
--- a/src/joint_state_listener.cpp
+++ b/src/joint_state_listener.cpp
@@ -80,7 +80,7 @@ JointStateListener::JointStateListener(
 
   use_tf_static_ = true;
   ignore_timestamp_ = false;
-  tf_prefix_ = "";
+  tf_prefix_ = node_->declare_parameter("tf_prefix", "");
   // auto publish_freq = 50.0;
   // publish_interval_ = std::chrono::seconds(1.0/std::max(publish_freq, 1.0));
   publish_interval_ = 1s;


### PR DESCRIPTION
Without it there is no way to pass `tf_prefix` to `robot_state_publisher` and I can't see any other clear way to launch it for multiple robots.

If you know other ways, please leave your answer here:
https://answers.ros.org/question/334501/is-there-common-way-to-run-multiple-robots-in-ros2/